### PR TITLE
Avoid loading non-media files to RS5K

### DIFF
--- a/FX specific/mpl_RS5k tools/mpl_List next sample in directory for focused RS5k.lua
+++ b/FX specific/mpl_RS5k tools/mpl_List next sample in directory for focused RS5k.lua
@@ -22,7 +22,7 @@ function main()
       local i = 0
       repeat
       local file = reaper.EnumerateFiles( path, i )
-      if file then
+      if file and reaper.IsMediaExtension(file:gsub('.+%.', ''), false) then
         files[#files+1] = file
       end
       i = i+1

--- a/FX specific/mpl_RS5k tools/mpl_List previous sample in directory for focused RS5k.lua
+++ b/FX specific/mpl_RS5k tools/mpl_List previous sample in directory for focused RS5k.lua
@@ -22,7 +22,7 @@ function main()
       local i = 0
       repeat
       local file = reaper.EnumerateFiles( path, i )
-      if file then
+      if file and reaper.IsMediaExtension(file:gsub('.+%.', ''), false) then
         files[#files+1] = file
       end
       i = i+1

--- a/FX specific/mpl_RS5k tools/mpl_List random sample in directory for focused RS5k.lua
+++ b/FX specific/mpl_RS5k tools/mpl_List random sample in directory for focused RS5k.lua
@@ -31,7 +31,7 @@ function main()
       local i = 0
       repeat
       local file = reaper.EnumerateFiles( path, i )
-      if file then
+      if file and reaper.IsMediaExtension(file:gsub('.+%.', ''), false) then
         files[#files+1] = file
       end
       i = i+1


### PR DESCRIPTION
When using this script with ReaSamplomatic5000, the script would choose any file from the folder where already loaded sample is. But, it would also load non-media files from that folder and that would silence ReaSamplomatic5000 and user would need to run the script again and again just to get to a valid media file. This is now fixed.
