### PR TITLE
Set Midi NONE for Sidechain routing

### DIFF
--- a/FX specific/mpl_Create ReaComp sidechain routing (inversed source destination).lua
+++ b/FX specific/mpl_Create ReaComp sidechain routing (inversed source destination).lua
@@ -61,6 +61,7 @@
             SetTrackSendInfo_Value( src_tr, 0, new_id, 'D_VOL', defsendvol)
             SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_SENDMODE', 3)
             SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_DSTCHAN', 2) -- 3/4
+            SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_MIDIFLAGS', 31) -- MIDI None
           end
         end
       end

--- a/FX specific/mpl_Create ReaComp sidechain routing.lua
+++ b/FX specific/mpl_Create ReaComp sidechain routing.lua
@@ -66,6 +66,7 @@
           SetTrackSendInfo_Value( src_tr, 0, new_id, 'D_VOL', defsendvol)
           SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_SENDMODE', 3)
           SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_DSTCHAN', 2) -- 3/4
+          SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_MIDIFLAGS', 31) -- MIDI None
         end
       end
   end

--- a/FX specific/mpl_Create ReaGate sidechain routing (inversed source destination).lua
+++ b/FX specific/mpl_Create ReaGate sidechain routing (inversed source destination).lua
@@ -58,6 +58,7 @@
             new_id = CreateTrackSend( src_tr, dest_tr )
             SetTrackSendInfo_Value( src_tr, 0, new_id, 'D_VOL', defsendvol)
             SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_DSTCHAN', 2) -- 3/4
+            SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_MIDIFLAGS', 31) -- MIDI None
           end
         end
       end

--- a/FX specific/mpl_Create ReaGate sidechain routing.lua
+++ b/FX specific/mpl_Create ReaGate sidechain routing.lua
@@ -52,6 +52,7 @@
           if not new_id then new_id = CreateTrackSend( src_tr, dest_tr ) end
           SetTrackSendInfo_Value( src_tr, 0, new_id, 'D_VOL', defsendvol)
           SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_DSTCHAN', 2) -- 3/4
+          SetTrackSendInfo_Value( src_tr, 0, new_id, 'I_MIDIFLAGS', 31) -- MIDI None
         end
       end
     


### PR DESCRIPTION
If you have a midi track (Track A) that functions as a sidechain trigger and you sidechain it to another midi track (Track B) that is being ducked by the compressor, the midi data from the sidechain trigger is sent to Track B, which causes unwanted audio.

With this change, the routing excludes midi data (sets Midi to 'None'):

![image](https://user-images.githubusercontent.com/2265452/160231215-6255c5ed-c1cd-4412-b538-8f053ab1ae78.png)


