### PR TITLE
fix: RS5K mgr handle invalid media source lengths and prevent crashes

### DIFF
--- a/FX specific/mpl_RS5K_manager_functions.lua
+++ b/FX specific/mpl_RS5K_manager_functions.lua
@@ -1619,7 +1619,11 @@ end
     
     local src = PCM_Source_CreateFromFileEx(filename, true )
     if not src then return end  
-    local src_len =  GetMediaSourceLength( src ) 
+    local src_len =  GetMediaSourceLength( src )
+    if not src_len or src_len <= 0 then
+      PCM_Source_Destroy( src )
+      return
+    end
     local stoffs_sec = 0
     local slice_len = src_len
     if ignoreboundary~= true then
@@ -3518,7 +3522,11 @@ end
     -- store external data
       local src = PCM_Source_CreateFromFileEx( filename, true )
       if src then
-        local src_len =  GetMediaSourceLength( src )  
+        local src_len =  GetMediaSourceLength( src )
+        if not src_len or src_len <= 0 then
+          PCM_Source_Destroy( src )
+          return
+        end
         
         -- auto normalization
         if EXT.CONF_onadd_autoLUFSnorm_toggle == 1 then 
@@ -4229,8 +4237,9 @@ end
   function DATA:Actions_TemporaryGetAudio(filename) 
     
     local PCM_Source = PCM_Source_CreateFromFile( filename )
+    if not PCM_Source then return end
     local srclen, lengthIsQN = reaper.GetMediaSourceLength( PCM_Source )
-    if srclen > EXT.CONF_crop_maxlen then
+    if not srclen or srclen <= 0 or srclen > EXT.CONF_crop_maxlen then
       --if PCM_Source then  PCM_Source_Destroy( PCM_Source )  end
       return
     end
@@ -4603,8 +4612,9 @@ end
     
     -- build PCM
     local PCM_Source = PCM_Source_CreateFromFile( filename )
+    if not PCM_Source then return end
     local srclen, lengthIsQN = GetMediaSourceLength( PCM_Source )
-    if lengthIsQN ==true or (srclen < EXT.CONF_loopcheck_minlen or srclen > EXT.CONF_loopcheck_maxlen) then 
+    if not srclen or srclen <= 0 or lengthIsQN ==true or (srclen < EXT.CONF_loopcheck_minlen or srclen > EXT.CONF_loopcheck_maxlen) then 
       --PCM_Source_Destroy( PCM_Source )
       return
     end

--- a/MIDI/mpl_Export selected items as MIDI files into project path.lua
+++ b/MIDI/mpl_Export selected items as MIDI files into project path.lua
@@ -33,9 +33,11 @@
 
   ---------------------------------------------------------------------  
   function main() 
-    -- collect takes
+    -- collect takes and preserve selection
+      local selected_items = {}
       for i =1 , CountSelectedMediaItems(0)do
         local item = GetSelectedMediaItem(0,i-1)
+        selected_items[#selected_items+1] = item
         local take = GetActiveTake(item)
         local retval, tkname = GetSetMediaItemTakeInfo_String( take, 'P_NAME', '', false )
         local track = GetMediaItemTrack( item )
@@ -67,6 +69,12 @@
       
     -- export to midi file
      for i =1, #DATA2.takes do DATA2:ExportMIDIFiles(DATA2.takes[i]) end
+     
+    -- restore selection
+      for i = 1, #selected_items do
+        SetMediaItemSelected(selected_items[i], true)
+      end
+      UpdateArrange()
   end
   ---------------------------------------------------------------------  
   function DATA2:MIDIEditor_SetEvts(tk_t)

--- a/MIDI/mpl_Export selected items as MIDI files into project path.lua
+++ b/MIDI/mpl_Export selected items as MIDI files into project path.lua
@@ -117,9 +117,19 @@
       end
     end
     
-    -- all note off
-    local ppq_cur = t[#t].ppq_pos
-    str = str..string.pack("i4Bs4", 0, t[#t].flags&0xF , t[#t].msg1)
+    -- all note off - place at item end to respect item length including silence
+    local item_len = GetMediaItemInfo_Value(tk_t.item, 'D_LENGTH')
+    local item_pos = GetMediaItemInfo_Value(tk_t.item, 'D_POSITION')
+    local take_start_offset = GetMediaItemTakeInfo_Value(take, 'D_STARTOFFS')
+    local qn_start = TimeMap2_timeToQN(nil, item_pos - take_start_offset)
+    local qn_end = TimeMap2_timeToQN(nil, item_pos + item_len - take_start_offset)
+    local ppq_start = MIDI_GetPPQPosFromProjQN(take, qn_start)
+    local ppq_end = MIDI_GetPPQPosFromProjQN(take, qn_end)
+    local item_len_ppq = ppq_end - ppq_start
+    
+    local ppq_cur = math.max(t[#t].ppq_pos, item_len_ppq)
+    local offset_to_end = ppq_cur - ppq_last
+    str = str..string.pack("i4Bs4", offset_to_end, t[#t].flags&0xF , t[#t].msg1)
     
     -- set / sort
     if tk_t.src_events then


### PR DESCRIPTION
Hi and thanks for your wonderful work, I was playing around with some scripts from you and was digging through some of the code to find some solutions to minor issues I had.
I hope it's okay for me to create this PR where I tried to split the fixes into separate commits with messages what the intention was. You're welcome to reject the PR if it's not what the project needs, I'm new to this repository and lua/Reaper scripting in general.

First one was `MIDI/mpl_Export selected items as MIDI files into project path.lua` where I noticed it loses the selection after executing the script, which doesn't play well with adding more actions to the selection (or to add to or remove from the selection).

I also noticed the Media Item length wasn't respected - this is debatable, since if we export only the existing MIDI events, the loop only spans those events, but I was creating drum loops and the .mid files didn't span the length of the media items (and the Action indicates the "media item" itself is being exported, which spans a longer time than the events).
The workaround is to always manually add some event (silent note or CC) to the end of the selection to ensure that the whole media item length is respected, but my commit does this out of the box - maybe a boolean makes more sense to toggle if auto-adding to the end of the media item is the wanted behavior?

I also tried to auto-name the files based on the media item's name and noticed special characters could cause issues (at least on Windows) so I added basic filename sanitation. Maybe there's a better way to do this?

Regarding RS5K Manager, I had a runtime error crashing the plugin whenever it loaded an "empty" file (0 Byte .wav files) from a Database. The error helped me find some folders in the database where I had indeed some empty files, but a runtime error didn't fully explain what was going on so I thought it would be better to just ignore empty files - I'm not 100% sure the commit fully fixes the issue but at least it highlights the problem.

Hope this is helpful to you or others using the plugin.
Please ask if something isn't clear and I'll try my best to give more insight.

Happy new year,
Bjarki