### PR TITLE
Fix: mpl_Adjust selected notes pitch: rename GetShortSmplName function call

### DIFF
--- a/MIDI editor/mpl_Adjust selected notes pitch (mousewheel).lua
+++ b/MIDI editor/mpl_Adjust selected notes pitch (mousewheel).lua
@@ -111,7 +111,7 @@
     if not take then return end
     
     local filename = ({reaper.get_action_context()})[2]
-    local script_title = GetShortSmplName(filename):gsub('%.lua','')
+    local script_title = VF_GetShortSmplName(filename):gsub('%.lua','')
     local oct_shift = script_title:match('octave')~= nil
     local inverted = script_title:match('inverted')~= nil
     local keysnap = script_title:match('keysnap')~= nil


### PR DESCRIPTION
Refactor error at MIDI editor/mpl_Adjust selected notes pitch script:
Rename "GetShortSmplName" to "VF_GetShortSmplName"